### PR TITLE
Added ability to fetch recipes

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,10 +1,20 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from datetime import date
 import os
 import json
 
 app = FastAPI()
 
+origins = ["*"]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 @app.get("/recipes")
 def recipes(start_date: date, end_date: date):

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,3 +1,62 @@
 from fastapi import FastAPI
+from datetime import date
+import os
+import json
 
 app = FastAPI()
+
+
+@app.get("/recipes")
+def recipes(start_date: date, end_date: date):
+    # fetches the json
+    data = load_data()
+
+    # filters by start and end date
+    data = filter_data(data=data, start_date=str(start_date), end_date=str(end_date))
+
+    if not data:
+        return
+
+    data_main, data_dessert, data_side = data
+
+    return [data_main, data_dessert, data_side]
+
+
+def load_data():
+    try:
+        current_dir = os.path.dirname(os.path.realpath(__file__))
+        f = open(current_dir + "/recipes.json", "r")
+        data = json.load(f)
+        f.close()
+
+        if data:
+            return data
+        else:
+            raise Exception(f"There's no recipe data")
+    except Exception as requestException:  # exception - fetching data was unsuccessful
+        raise Exception("There was a problem getting recipe data")
+
+
+def filter_data(data: list[dict], start_date: str, end_date: str):
+    filtered_data_main = []
+    filtered_data_side = []
+    filtered_data_dessert = []
+
+    for item in data:
+        if item["date"] >= start_date and item["date"] <= end_date:
+            if item["category"] == "Main":
+                filtered_data_main.append(item)
+            elif item["category"] == "Side":
+                filtered_data_side.append(item)
+            else:
+                filtered_data_dessert.append(item)
+
+    message = ""
+    if len(filtered_data_main + filtered_data_side + filtered_data_dessert) == 0:
+        message = "No recipes in the given time frame, stopping the process now."
+
+    if message:
+        print(message)
+        return False
+    else:
+        return filtered_data_main, filtered_data_side, filtered_data_dessert

--- a/backend/app/recipes.json
+++ b/backend/app/recipes.json
@@ -1,0 +1,102 @@
+[
+  {
+    "category": "Dessert",
+    "cooking_time": 50,
+    "date": "2023-08-02",
+    "difficulty": "Medium",
+    "preparation_time": 30,
+    "short_description": "Sweet orange segments, warm melted dark chocolate and a light orange cream, these stunning Pavlovas are the perfect way to finish any dinner.",
+    "title": "Chocolate & Orange Pavlovas",
+    "image_url": "https://images.prismic.io/oddbox/03e6cf3f-f3bb-46ed-914a-0928d11acf23_IMG_7841%202.JPG?ixlib=gatsbyFP&auto=compress%2Cformat&fit=max"
+  },
+  {
+    "category": "Main",
+    "cooking_time": 15,
+    "date": "2023-08-01",
+    "difficulty": "Easy",
+    "preparation_time": 10,
+    "short_description": "This express aubergine and white beans recipe can be made in 30 minutes. Feel free to swap the veg with whatever you have in your box every week, and use any white beans of your choice.",
+    "title": "Mediterranean Aubergine & White Beans",
+    "image_url": "https://images.prismic.io/oddbox/d184f523-9072-40e7-9f70-28a40993a2c2_IMG_7847%203.JPG?ixlib=gatsbyFP&auto=compress%2Cformat&fit=max"
+  },
+  {
+    "category": "Main",
+    "cooking_time": 0,
+    "date": "2023-07-26",
+    "difficulty": "Easy",
+    "preparation_time": 15,
+    "short_description": "Salad jars are perfect for a healthy lunch on busy days. Made ahead of time, easy to adapt and so delicious. You can store these for up to 3 days, making them perfect for meal prep and batch cooking. Our Thai red curry paste makes the creamiest and tastiest dressing in just minutes.",
+    "title": "Thai Red Curry Salad Jars",
+    "image_url": "https://images.prismic.io/oddbox/da289db2-18d8-4705-bc93-fcc85f310b89_IMG_7410.JPG?ixlib=gatsbyFP&auto=compress%2Cformat&fit=max"
+  },
+  {
+    "category": "Main",
+    "cooking_time": 0,
+    "date": "2023-07-25",
+    "difficulty": "Easy",
+    "preparation_time": 15,
+    "short_description": "A bircher is a great make-ahead breakfast and a handy recipe to have on hand.",
+    "title": "Blackberry Bircher",
+    "image_url": "https://images.prismic.io/oddbox/c5d6c998-4153-4d28-9c0e-c8b1df4891e7_IMG_7312%202.JPG?ixlib=gatsbyFP&auto=compress%2Cformat&fit=max"
+  },
+  {
+    "category": "Main",
+    "cooking_time": 20,
+    "date": "2023-07-25",
+    "difficulty": "Easy",
+    "preparation_time": 10,
+    "short_description": "An easy vegan version of a Thai noodle curry, packed with vegetables, coconut milk, chilli and showcasing our small batch of Thai red curry paste. A delicious warming family meal. ",
+    "title": "Carrot Thai Noodle Curry ",
+    "image_url": "https://images.prismic.io/oddbox/57ea6a41-16e7-496d-bf90-98118c993cd8_IMG_7398.JPG?ixlib=gatsbyFP&auto=compress%2Cformat&fit=max"
+  },
+  {
+    "category": "Side",
+    "cooking_time": 25,
+    "date": "2023-07-24",
+    "difficulty": "Medium",
+    "preparation_time": 120,
+    "short_description": "Crackingly crispy on the outside and scrumptiously soft on the inside, check out this balti focaccia bread recipe from @lagomchef! Made with our small batch Oddbox Balti paste, it makes for picnic perfection. Take the taste up a notch by serving with spicy Balti yoghurt, crispy fried onions and diced onion and coriander \u2013 this bread is a smash either solo or shared.",
+    "title": "Balti Focaccia",
+    "image_url": "https://images.prismic.io/oddbox/3916bc1b-ff57-4e78-8c45-45fdfbfbbdcc_IMG_9026.jpg?ixlib=gatsbyFP&auto=compress%2Cformat&fit=max"
+  },
+  {
+    "category": "Side",
+    "cooking_time": 20,
+    "date": "2023-07-20",
+    "difficulty": "Easy",
+    "preparation_time": 10,
+    "short_description": "Roasting radishes brings out their sweetness and this must-try recipe will turn anyone into a radish lover. We love them served over a creamy sauce made from yoghurt/vegan yoghurt and harissa.\u00a0",
+    "title": "Quick Garlic Roasted Radishes",
+    "image_url": "https://images.prismic.io/oddbox/4cff9ce3-9b0a-4b20-bdf6-d06f558e9fa9_IMG_7019%202.JPG?ixlib=gatsbyFP&auto=compress%2Cformat&fit=max"
+  },
+  {
+    "category": "Side",
+    "cooking_time": 15,
+    "date": "2023-07-19",
+    "difficulty": "Easy",
+    "preparation_time": 15,
+    "short_description": "Use any leftover vegetables for this recipe, such as carrots, onion, cabbage, potato, spring onions, broccoli, cauliflower and even cauliflower leaves.\u00a0",
+    "title": "Leftover Vegetable Bhajis with Yoghurt Balti Curry Dip",
+    "image_url": "https://images.prismic.io/oddbox/8c71a7e4-ec11-4fb5-b56a-332f0dcb28b9_IMG_7024%202.JPG?ixlib=gatsbyFP&auto=compress%2Cformat&fit=max"
+  },
+  {
+    "category": "Main",
+    "cooking_time": 20,
+    "date": "2023-07-19",
+    "difficulty": "Easy",
+    "preparation_time": 10,
+    "short_description": "Street food inspired roasted cauliflower pittas with our small batch of balti curry paste. Roasted crispy cauliflower stuffed pittas with all the extras. This loaded pitta is so good and makes for a fun, delicious, and different weeknight dinner.\u00a0",
+    "title": "Roasted Cauliflower Pittas with Balti Curry Paste",
+    "image_url": "https://images.prismic.io/oddbox/eaa2c34e-e004-4026-be57-dd26a5e95685_IMG_7106.JPG?ixlib=gatsbyFP&auto=compress%2Cformat&fit=max"
+  },
+  {
+    "category": "Main",
+    "cooking_time": 0,
+    "date": "2022-06-30",
+    "difficulty": "Easy",
+    "preparation_time": 10,
+    "short_description": "This classic cherry and chocolate flavour pairing is perfect for meal prep and batch cooking. Super quick, all the ingredients are added to up-cycled jam jars and kept in the fridge for breakfast.",
+    "title": "Cherry & Chocolate Overnight Oats",
+    "image_url": "https://images.prismic.io/oddbox/4e4dd1b9-ed14-4e8d-8824-c36619552136_IMG_2353.JPG?ixlib=gatsbyFP&auto=compress%2Cformat&fit=max"
+  }
+]

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "@types/node": "^16.18.76",
         "@types/react": "^18.2.48",
         "@types/react-dom": "^18.2.18",
+        "axios": "^1.6.7",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-scripts": "5.0.1",
@@ -5167,6 +5168,29 @@
       "integrity": "sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.4",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -14367,6 +14391,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/psl": {
       "version": "1.9.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "@types/node": "^16.18.76",
     "@types/react": "^18.2.48",
     "@types/react-dom": "^18.2.18",
+    "axios": "^1.6.7",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",

--- a/frontend/src/components/RecipeCard.css
+++ b/frontend/src/components/RecipeCard.css
@@ -1,0 +1,24 @@
+.Recipe-card {
+    width: 25%;
+}
+
+#Easy {
+    padding: 5px 15px;
+    display: inline-block;
+    background-color: rgb(190, 237, 190);
+    border-radius: 1000px
+}
+
+#Medium {
+    padding: 5px 15px;
+    display: inline-block;
+    background-color: rgb(218, 192, 107);
+    border-radius: 1000px
+}
+
+#Hard {
+    padding: 5px 15px;
+    display: inline-block;
+    background-color: rgb(212, 139, 139);
+    border-radius: 1000px
+}

--- a/frontend/src/components/RecipeCard.tsx
+++ b/frontend/src/components/RecipeCard.tsx
@@ -1,0 +1,27 @@
+import "./RecipeCard.css";
+
+interface RecipeCardProps {
+  title: string;
+  description: string;
+  image: string;
+  created_at: string; // Format will be DD-MM-YYYY
+  difficulty: "Easy" | "Medium" | "Difficult";
+}
+
+function RecipeCard(props: RecipeCardProps) {
+  return (
+    <section className="Recipe-card">
+      <h3>{props.title}</h3>
+      <img width="200" height="200" src={props.image} alt="img" />
+      <br />
+      <span>Created at: {props.created_at}</span>
+      <p>{props.description}</p>
+
+      {props.difficulty == "Easy" && <div id="Easy">Easy</div>}
+      {props.difficulty == "Medium" && <div id="Medium">Medium</div>}
+      {props.difficulty == "Difficult" && <div id="Difficult">Difficult</div>}
+    </section>
+  );
+}
+
+export default RecipeCard;

--- a/frontend/src/components/RecipeFilters.tsx
+++ b/frontend/src/components/RecipeFilters.tsx
@@ -1,0 +1,36 @@
+import "./RecipeFilters.css";
+import axios from 'axios'
+import { useState } from 'react';
+
+interface RecipeFiltersProps {
+  returnDataCallback: any
+}
+
+function RecipeFilters(props: RecipeFiltersProps) {
+
+  const [startDate, setStartDate] = useState<string>("")
+  const [endDate, setEndDate] = useState<string>("")
+
+
+  const fetch_data = () => {
+    console.log('clicked')
+    
+    // Fetch recipe data from backend
+    axios.get("http://localhost:8000/recipes?start_date=" + startDate + "&end_date=" + endDate).then((response) => {
+      console.log('response is', response.data);
+
+      // Pass recipe data from API back to the parent page
+      props.returnDataCallback(response.data)
+    }).catch((error) => console.log(error))
+  }
+
+  return (
+    <section className="Recipe-filters">
+        From: <input type="text" placeholder="YYYY-MM-DD" style={{'marginRight': "20px"}} onChange={(event) => setStartDate(event.target.value)}></input>
+        To date: <input type="text" placeholder="YYYY-MM-DD" style={{'marginRight': "20px"}} onChange={(event) => setEndDate(event.target.value)}></input>
+        <input type="button" value="Search" onClick={() => fetch_data()} />
+    </section>
+  );
+}
+
+export default RecipeFilters;

--- a/frontend/src/pages/App.css
+++ b/frontend/src/pages/App.css
@@ -15,3 +15,11 @@
   align-items: center;
   background-color: white;
 }
+
+.Recipe-card-container {
+  display: flex;
+  width: 100%;
+  flex-wrap: wrap;
+  justify-content: space-evenly;
+  gap: 20px;
+}

--- a/frontend/src/pages/App.tsx
+++ b/frontend/src/pages/App.tsx
@@ -1,12 +1,50 @@
-import './App.css';
-import Header from '../components/Header';
+import "./App.css";
+import Header from "../components/Header";
+import RecipeCard from "../components/RecipeCard";
+import RecipeFilters from "../components/RecipeFilters";
+import { useState } from "react";
+
+interface RecipeData {
+  title: string;
+  category: string;
+  cooking_time: number;
+  date: string;
+  difficulty: any;
+  image_url: string;
+  short_description: string;
+}
 
 function App() {
+  const [recipeArrays, setRecipes] = useState<RecipeData[][]>([]);
+
   return (
     <div className="App">
       <Header />
       <section className="App-body">
         <h1>Welcome to the Oddbox Recipe Finder!</h1>
+        <p>Enter your start date and end date below, and this page will filter your recipes by recipe category.</p>
+        <RecipeFilters returnDataCallback={(data: any) => setRecipes(data)} />
+        {recipeArrays.map((recipeArray) => {
+          return (
+            <>
+              <h2>Category: {recipeArray[0].category}</h2>
+              <section className="Recipe-card-container">
+                {recipeArray.map((recipe) => {
+                  return (
+                    <RecipeCard
+                      key="key"
+                      title={recipe.title}
+                      description={recipe.short_description}
+                      image={recipe.image_url}
+                      difficulty={recipe.difficulty}
+                      created_at={recipe.date}
+                    />
+                  );
+                })}
+              </section>
+            </>
+          );
+        })}
       </section>
     </div>
   );


### PR DESCRIPTION
**NOTE:** _This pull request is part of Oddbox's technical test. This pull request is a mock pull request for candidates. None of this code is for real world production use._ 

# Purpose

This change provides the ability to easily see a list of recipes between a date range and grouped by category (e.g. main, dessert, side).

The marketing team asked for this as they want customers to have a place where they can easily filter recipes between two dates, and customers generally want this grouped by category. In the future, the marketing team said they will likely be adding new categories of recipes.

The marketing team told us customers regularly access this data on the go from their mobile devices, so the page should also be responsive. 

I was not provided any wireframes for how this should look, and so I have gone with a grid system using flexbox so that it is responsive. 

# Approach

I have created some backend and frontend code. The backend code loads the recipe data between two dates and groups by category (currently loaded from a JSON of recipes, this will be a database of recipes at some point). 

The backend has an API endpoint `recipes/` which returns recipes provided between two dates. For example: `recipes/?start_date=2022-07-25&end_date=2024-08-25`

The frontend allows a user to enter the dates they want to filter by, and then shows the recipes in a grid format. I've attached a screenshot of how this looks with some recipes:

![localhost_3000_ copy](https://github.com/OddboxHQ/technical-test-recipe-app/assets/7669263/8dbeb849-bf73-4c9a-be75-e86edc076725)



